### PR TITLE
Py3 compat.

### DIFF
--- a/flake8diff/main.py
+++ b/flake8diff/main.py
@@ -129,7 +129,7 @@ def main():
             options=options,
         ).process()
     except Exception as e:
-        parser.error(e.message or six.text_type(e))
+        parser.error(six.text_type(e))
 
     if any_violations:
         sys.exit(1)

--- a/flake8diff/utils.py
+++ b/flake8diff/utils.py
@@ -26,4 +26,4 @@ def _execute(cmd, strict=False):
         if strict:
             raise subprocess.CalledProcessError(return_code, cmd)
 
-    return out
+    return out.decode('utf-8')


### PR DESCRIPTION
Two small python 3 issues:

  - `subprocess.Popen` returns command output as bytestring, not string
  - Exceptions have no 'message' attribute

Fixes tested on python 3.4.2/linux.
