### PR TITLE
String modes

### DIFF
--- a/flake8diff/flake8.py
+++ b/flake8diff/flake8.py
@@ -200,8 +200,8 @@ class Flake8Diff(object):
                 matches = FLAKE8_LINE.match(violation)
                 if matches:
                     violation_details = matches.groupdict()
-                    if self.should_include_violation(violation_details,
-                                                     changed_lines):
+                    if self._should_include_violation(violation_details,
+                                                      changed_lines):
                         violations.append(violation_details)
                         if self.options.get('standard_flake8_output'):
                             print(FLAKE8_OUTPUT.format(

--- a/flake8diff/main.py
+++ b/flake8diff/main.py
@@ -21,7 +21,7 @@ import os
 import six
 import sys
 
-from .flake8 import COLORS, Flake8Diff
+from .flake8 import COLORS, STRICT_MODES, Flake8Diff
 from .vcs import SUPPORTED_VCS
 
 
@@ -103,6 +103,17 @@ parser.add_argument(
          ''.format(default_color,
                    ', '.join(COLORS.keys())),
 )
+parser.add_argument(
+    '--strict-mode',
+    choices=STRICT_MODES.keys(),
+    default='only_lines',
+    type=six.text_type,
+    dest='strict_mode',
+    help='Strict mode to use on the files where violations are found. '
+         'Default is "only_lines". '
+         'Can be any of "{0}"'
+         ''.format(', '.join(STRICT_MODES.keys())),
+)
 
 
 def main():
@@ -116,6 +127,7 @@ def main():
         'flake8_options': args.flake8_options,
         'standard_flake8_output': args.standard_flake8_output,
         'color_theme': args.color,
+        'strict_mode': args.strict_mode,
     }
 
     # adjust logging level


### PR DESCRIPTION
flake8 can be fooled. for example:

```diff
class Foo(object): pass


+
+
class Bar(object):pass
```

technically there is now a violation on `Bar` since there are too many blank lines however flake8-diff will not detect it since the diff only added the blank lines which is not where violation is.

The idea of strict modes is to allow to choose how files are evaluated.

* `only_lines` - default and existing behaviour which only counts violations when that specific line is added and it has a violation
* `file` - uses all violations from any modified files in the diff

possible strict modes for the future

* `percent_file` - uses all violations from any modified files when specific percent of lines was modified in the file. for example if only 2 lines were modified in 1000 line file, dont bother, but on the other hand if 600 lines were modified, then probably a good idea to lint the whole file, same as `file` strict mode