### PR TITLE
Introduce Mercurial Support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@
 ### Contributors
 
 * Miroslav Shubernetskiy - miroslav.shubernetskiy@dealertrack.com
+* RhodeCode GmbH (develop@rhodecode.com)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Documentation
    :maxdepth: 2
 
    usage
+   mercurial
 
 
 API documentation

--- a/docs/mercurial.rst
+++ b/docs/mercurial.rst
@@ -1,0 +1,7 @@
+=================
+Mercurial Support
+=================
+
+In order to use mercurial, you need to be sure that `extdiff` extension is
+enabled. Please check the following page for more details:
+https://mercurial.selenic.com/wiki/ExtdiffExtension 

--- a/flake8diff/exceptions.py
+++ b/flake8diff/exceptions.py
@@ -1,7 +1,15 @@
 from __future__ import unicode_literals, print_function
 
+import six
 
-class Flake8NotInstalledError(Exception):
+
+@six.python_2_unicode_compatible
+class BaseError(Exception):
+    def __str__(self):
+        return self.message
+
+
+class Flake8NotInstalledError(BaseError):
     """
     Exception when run_flake8 installation cannot be found.
     """
@@ -9,14 +17,14 @@ class Flake8NotInstalledError(Exception):
                'Is it on $PATH?')
 
 
-class NotLocatableVCSError(Exception):
+class NotLocatableVCSError(BaseError):
     """
     Exceptions for when VCS cannot be determined automatically
     """
     message = 'VCS could not be determined automatically'
 
 
-class UnsupportedVCSError(Exception):
+class UnsupportedVCSError(BaseError):
     """
     Exception for handling unknown VCS
     """
@@ -24,9 +32,10 @@ class UnsupportedVCSError(Exception):
     def __init__(self, vcs=None):
         msg = '{0} VCS is not unsupported'
         self.message = msg.format(vcs)
+        super(UnsupportedVCSError, self).__init__()
 
 
-class VCSNotInstalledError(Exception):
+class VCSNotInstalledError(BaseError):
     """
     Exception for when particular vcs installation
     cannot be found.
@@ -36,3 +45,15 @@ class VCSNotInstalledError(Exception):
         msg = ('VCS "{0}" installation could not be found. '
                'Is it on $PATH?')
         self.message = msg.format(vcs)
+        super(VCSNotInstalledError, self).__init__()
+
+
+class WrongVCSSpecified(BaseError):
+    """
+    Exception for when particular vcs installation
+    cannot be found.
+    """
+
+    def __init__(self, vcs=None):
+        self.message = 'This is not a "{0}" repository'.format(vcs or '')
+        super(WrongVCSSpecified, self).__init__()

--- a/flake8diff/flake8.py
+++ b/flake8diff/flake8.py
@@ -7,6 +7,7 @@ from .exceptions import (
     Flake8NotInstalledError,
     NotLocatableVCSError,
     UnsupportedVCSError,
+    WrongVCSSpecified,
 )
 from .utils import _execute
 from .vcs import SUPPORTED_VCS
@@ -103,11 +104,17 @@ class Flake8Diff(object):
             vcs = self.options.get('vcs')
             if vcs not in SUPPORTED_VCS:
                 raise UnsupportedVCSError(vcs)
-            return SUPPORTED_VCS.get(vcs)(self.commits, self.options)
+            supported_vcs = SUPPORTED_VCS.get(vcs)
+            if supported_vcs:
+                supported_vcs = supported_vcs(self.commits, self.options)
+                if supported_vcs.is_used() and supported_vcs.check():
+                    return supported_vcs
+                else:
+                    raise WrongVCSSpecified(vcs)
 
         for vcs in SUPPORTED_VCS.values():
             vcs = vcs(self.commits, self.options)
-            if vcs.is_used():
+            if vcs.is_used() and vcs.check():
                 return vcs
 
         raise NotLocatableVCSError

--- a/flake8diff/utils.py
+++ b/flake8diff/utils.py
@@ -6,7 +6,7 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-def _execute(cmd, strict=False):
+def _execute(cmd, strict=False, log_errors=True):
     """
     Make executing a command locally a little less painful
     """
@@ -22,7 +22,8 @@ def _execute(cmd, strict=False):
     # status code when any violations have been found
     # so only log if error message is present
     if return_code != 0 and (err or strict):
-        logger.error(err)
+        if log_errors:
+            logger.error(err)
         if strict:
             raise subprocess.CalledProcessError(return_code, cmd)
 

--- a/flake8diff/vcs/__init__.py
+++ b/flake8diff/vcs/__init__.py
@@ -3,6 +3,7 @@ import inspect
 
 from .base import VCSBase
 from .git import GitVCS  # noqa
+from .hg import HgVCS  # noqa
 
 
 SUPPORTED_VCS = dict(

--- a/flake8diff/vcs/base.py
+++ b/flake8diff/vcs/base.py
@@ -49,3 +49,9 @@ class VCSBase(object):
         Return a list of all changed files.
         """
         raise NotImplementedError
+
+    def check(self):
+        """
+        Returns True if the configuration is correct or raises the exception
+        """
+        return True

--- a/flake8diff/vcs/git.py
+++ b/flake8diff/vcs/git.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals, print_function
 
 import logging
+import subprocess
+
 from ..utils import _execute
 from .base import VCSBase
 
@@ -23,9 +25,11 @@ class GitVCS(VCSBase):
     def is_used(self):
         """
         Determines if this VCS should be used
-
-        TODO: implement
         """
+        try:
+            self._is_git_repository()
+        except subprocess.CalledProcessError:
+            return False
         return True
 
     def changed_lines(self, filename):
@@ -65,3 +69,7 @@ class GitVCS(VCSBase):
         return filter(self.filter_file,
                       iter(_execute(' '.join(command))
                            .splitlines()))
+
+    def _is_git_repository(self):
+        return _execute(
+            '{vcs} status'.format(vcs=self.vcs), strict=True, log_errors=False)

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -1,0 +1,45 @@
+from __future__ import unicode_literals, print_function
+
+import logging
+import subprocess
+
+from ..utils import _execute
+from .base import VCSBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class HgVCS(VCSBase):
+    """
+    Mercurial support implementation
+    """
+    name = 'hg'
+
+    def get_vcs(self):
+        """
+        Get git binary executable path
+        """
+        vcs = _execute('which hg', strict=True).strip()
+        self._check_extdiff_extension(vcs)
+        return vcs
+
+    def is_used(self):
+        """
+        Determines if this VCS should be used
+
+        TODO: implement
+        """
+        return True
+
+    def _check_extdiff_extension(self, vcs):
+        try:
+            return _execute('{vcs} extdiff'.format(vcs=vcs), strict=True)
+        except subprocess.CalledProcessError:
+            message = (
+                "Mercurial 'extdiff' extension is disabled.\n"
+                "Please add the following lines to your ~/.hgrc\n\n"
+                "[extensions]\n"
+                "extdiff = \n")
+            print(message)
+            raise Exception("Please enable 'extdiff' extension")

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -28,7 +28,7 @@ class HgVCS(VCSBase):
         Determines if this VCS should be used
         """
         try:
-            self._check_mercurial_repository()
+            self._is_mercurial_repository()
         except subprocess.CalledProcessError:
             return False
         return True
@@ -83,6 +83,6 @@ class HgVCS(VCSBase):
             raise Exception("Please enable 'extdiff' extension")
         return True
 
-    def _check_mercurial_repository(self):
+    def _is_mercurial_repository(self):
         return _execute(
             '{vcs} status'.format(vcs=self.vcs), strict=True, log_errors=False)

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -66,7 +66,7 @@ class HgVCS(VCSBase):
             line.split('|')[0].strip()
             for line in lines
         ]
-        return files
+        return filter(self.filter_file, files)
 
     def check(self):
         try:

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -32,6 +32,22 @@ class HgVCS(VCSBase):
         """
         return True
 
+    def changed_lines(self, filename):
+        """
+        Get a list of all lines changed by this set of commits.
+        """
+        commits = ['-r {}'.format(c) for c in self.commits]
+        command_arguments = [
+            '-p diff',
+            '-o --new-line-format="%dn "',
+            '-o --unchanged-line-format=""',
+            '-o --changed-group-format="%\>"',
+            filename
+        ]
+        command = [self.vcs, 'extdiff'] + commits + command_arguments
+        result = _execute(' '.join(command))
+        return result.strip().split()
+
     def changed_files(self):
         """
         Return a list of all changed files.

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -38,16 +38,21 @@ class HgVCS(VCSBase):
         Get a list of all lines changed by this set of commits.
         """
         commits = ['-r {}'.format(c) for c in self.commits]
+
         command_arguments = [
-            '-p diff',
-            '-o --new-line-format="%dn "',
-            '-o --unchanged-line-format=""',
-            '-o --changed-group-format="%\>"',
+            "--program=diff",
+            "'--option=--new-line-format=\"%dn \"'",
+            "'--option=--unchanged-line-format=\"\"'",
+            "'--option=--changed-group-format=\"%>\"'",
             filename
         ]
         command = [self.vcs, 'extdiff'] + commits + command_arguments
         result = _execute(' '.join(command))
-        return result.strip().split()
+
+        # Fixes few compatibility issues
+        result = result.replace('"', '').strip().split(' ')
+
+        return result
 
     def changed_files(self):
         """

--- a/flake8diff/vcs/hg.py
+++ b/flake8diff/vcs/hg.py
@@ -32,6 +32,20 @@ class HgVCS(VCSBase):
         """
         return True
 
+    def changed_files(self):
+        """
+        Return a list of all changed files.
+        """
+        commits = ['-r {}'.format(c) for c in self.commits]
+        command = [self.vcs, 'diff', '--stat'] + commits
+        result = _execute(' '.join(command))
+        lines = result.strip().split('\n')[:-1]
+        files = [
+            line.split('|')[0].strip()
+            for line in lines
+        ]
+        return files
+
     def _check_extdiff_extension(self, vcs):
         try:
             return _execute('{vcs} extdiff'.format(vcs=vcs), strict=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ MarkupSafe==0.18
 Pygments==1.6
 Sphinx==1.2.2
 docutils==0.11
+six==1.9.0
 sphinx-rtd-theme==0.1.6


### PR DESCRIPTION
Introduces basic Mercurial support based on `extdiff` mercurial extension.

### How to test:
* Install mercurial
* Install `flake8-diff`
* Enable the `extdiff` support in your local `~/.hgrc` file:
```ini
[extensions]
extdiff = 
```
* Create a new mercurial repository using `hg init <repository name>`
* Create an initial commit with a PEP8-compatible python file
* Bookmark that commit using `hg bookmark initial`
* Add few PEP8 incompatible changes to that file and commit them
* Run `flake8-diff --vcs=hg initial` and check that the issues found by Flake8 are displayed. 
